### PR TITLE
Document POST /subscription

### DIFF
--- a/userapi/subscription.yaml
+++ b/userapi/subscription.yaml
@@ -119,11 +119,11 @@ post:
             code:
               type: string
               description: Subscription claim code
-              example: "ABCD-EFGH-IJKL"
+              example: "BCDF-FGHJ"
         examples:
           basic:
             value:
-              code: "ABCD-EFGH-IJKL"
+              code: "BCDF-FGHJ"
 
   responses:
     '200':


### PR DESCRIPTION
Adds OpenAPI documentation for POST /subscription (claim by code), aligned with legacy behavior and existing endpoint style.

closes#56