### PR TITLE
Add session management endpoints and schemas

### DIFF
--- a/components/schemas/Session.yaml
+++ b/components/schemas/Session.yaml
@@ -1,0 +1,29 @@
+type: object
+required:
+  - id
+  - createdAt
+  - lastAccessed
+  - current
+properties:
+  id:
+    type: integer
+    format: int64
+    description: Unique identifier of the active session.
+    example: 984231
+
+  createdAt:
+    type: integer
+    format: int64
+    description: Epoch timestamp in seconds when the session was created.
+    example: 1764412800
+
+  lastAccessed:
+    type: integer
+    format: int64
+    description: Epoch timestamp in seconds when the session was last used.
+    example: 1764448800
+
+  current:
+    type: boolean
+    description: Whether this session authorized the current request.
+    example: true

--- a/userapi/openapi.yaml
+++ b/userapi/openapi.yaml
@@ -24,6 +24,8 @@ tags:
     description: User registration and verification
   - name: Sensor-Settings
     description: Sensor settings management
+  - name: Sessions
+    description: Authenticated session management
   - name: Push-Notifications
     description: Push notification token management
   - name: Sensors
@@ -47,6 +49,10 @@ paths:
     $ref: './sensor-settings.yaml'
   /sensors-dense:
     $ref: './sensors-dense.yaml'
+  /sessions:
+    $ref: './sessions.yaml'
+  /sessions/{id}:
+    $ref: './sessions-id.yaml'
   /share:
     $ref: './share.yaml'
   /subscription:

--- a/userapi/sessions-id.yaml
+++ b/userapi/sessions-id.yaml
@@ -46,7 +46,7 @@ delete:
             unauthorized:
               value:
                 result: "error"
-                error: "Unauthorized"
+                error: "UNAUTHORIZED"
                 code: "ER_UNAUTHORIZED"
 
     '404':
@@ -59,5 +59,5 @@ delete:
             not_found:
               value:
                 result: "error"
-                error: "Not Found"
+                error: "NOT FOUND"
                 code: "ER_NOT_FOUND"

--- a/userapi/sessions-id.yaml
+++ b/userapi/sessions-id.yaml
@@ -1,0 +1,63 @@
+delete:
+  summary: Delete a session
+  description: Deletes a single active session by ID.
+  operationId: deleteSession
+  tags:
+    - Sessions
+  security:
+    - bearerAuth: []
+
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+      description: ID of the session to delete.
+      example: 984231
+
+  responses:
+    '200':
+      description: Session deleted successfully
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../components/schemas/Success.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: false
+          examples:
+            success:
+              value:
+                result: success
+                data: {}
+
+    '401':
+      description: UNAUTHORIZED - Auth token missing or invalid
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+          examples:
+            unauthorized:
+              value:
+                result: "error"
+                error: "Unauthorized"
+                code: "ER_UNAUTHORIZED"
+
+    '404':
+      description: NOT FOUND - Session does not exist
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+          examples:
+            not_found:
+              value:
+                result: "error"
+                error: "Not Found"
+                code: "ER_NOT_FOUND"

--- a/userapi/sessions.yaml
+++ b/userapi/sessions.yaml
@@ -54,7 +54,7 @@ get:
             unauthorized:
               value:
                 result: "error"
-                error: "Unauthorized"
+                error: "UNAUTHORIZED"
                 code: "ER_UNAUTHORIZED"
 
 delete:
@@ -97,5 +97,5 @@ delete:
             unauthorized:
               value:
                 result: "error"
-                error: "Unauthorized"
+                error: "UNAUTHORIZED"
                 code: "ER_UNAUTHORIZED"

--- a/userapi/sessions.yaml
+++ b/userapi/sessions.yaml
@@ -1,0 +1,101 @@
+get:
+  summary: List current sessions
+  description: |
+    Returns the authenticated user's active sessions.
+
+    Sessions are ordered by most recent access first.
+  operationId: getSessions
+  tags:
+    - Sessions
+  security:
+    - bearerAuth: []
+
+  responses:
+    '200':
+      description: Active sessions retrieved successfully
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../components/schemas/Success.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - sessions
+                    properties:
+                      sessions:
+                        type: array
+                        items:
+                          $ref: '../components/schemas/Session.yaml'
+          examples:
+            success:
+              value:
+                result: success
+                data:
+                  sessions:
+                    - id: 984231
+                      createdAt: 1764412800
+                      lastAccessed: 1764448800
+                      current: true
+                    - id: 984115
+                      createdAt: 1764301200
+                      lastAccessed: 1764387600
+                      current: false
+
+    '401':
+      description: UNAUTHORIZED - Auth token missing or invalid
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+          examples:
+            unauthorized:
+              value:
+                result: "error"
+                error: "Unauthorized"
+                code: "ER_UNAUTHORIZED"
+
+delete:
+  summary: Delete all current sessions
+  description: |
+    Deletes all active sessions for the authenticated user, including the session
+    used to authorize this request.
+  operationId: deleteSessions
+  tags:
+    - Sessions
+  security:
+    - bearerAuth: []
+
+  responses:
+    '200':
+      description: All active sessions deleted successfully
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../components/schemas/Success.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: false
+          examples:
+            success:
+              value:
+                result: success
+                data: {}
+
+    '401':
+      description: UNAUTHORIZED - Auth token missing or invalid
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+          examples:
+            unauthorized:
+              value:
+                result: "error"
+                error: "Unauthorized"
+                code: "ER_UNAUTHORIZED"

--- a/userapi/sessions.yaml
+++ b/userapi/sessions.yaml
@@ -41,7 +41,7 @@ get:
                       current: true
                     - id: 984115
                       createdAt: 1764301200
-                      lastAccessed: 1764387600
+                      lastAccessed: 1764387601
                       current: false
 
     '401':


### PR DESCRIPTION
Adds:
  - GET /sessions — lists sessions                                                                                                                     
  - DELETE /sessions — delete all sessions                                                                                                                                      
  - DELETE /sessions/{id} — delete a single session by ID

[edit] closes #61 